### PR TITLE
Prise en charge du multi-compteurs

### DIFF
--- a/core/class/veolia_eau_process.class.php
+++ b/core/class/veolia_eau_process.class.php
@@ -405,7 +405,7 @@ class veolia_eau extends eqLogic {
                 );
                 $extension='.xls';
                 break;
-           
+
            case 6:
             	log::add('SEE', 'debug', 'downloadToken : '.$downloadToken);
             	$url_token = 'https://www.eauxdelessonne.com/mon-compte-en-ligne/je-me-connecte';
@@ -509,6 +509,8 @@ class veolia_eau extends eqLogic {
 				curl_setopt($ch, CURLOPT_URL, $url_consommation);
 				curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 				curl_setopt($ch, CURLOPT_FILE, $fp);
+        $idAbt = ($this->getConfiguration('idAbt',0)=='') ? 0 : $this->getConfiguration('idAbt',0);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, 'idAbt=' . $idAbt);
 
                 if ($mock_test >= 2) {
                     $response = 1;

--- a/desktop/php/veolia_eau.php
+++ b/desktop/php/veolia_eau.php
@@ -136,6 +136,13 @@ $eqLogics = eqLogic::byType($plugin->getId());
                         </div>
 
                         <div class="form-group">
+                            <label class="col-sm-3 control-label">{{Identifiant compteur}}</label>
+                            <div class="col-sm-3">
+                                <input type="number" class="eqLogicAttr configuration form-control" data-l1key="configuration" data-l2key="idAbt" placeholder="0, 1, 2... si plusieurs compteurs rattaché au contrat"/>
+                            </div>
+                        </div>
+
+                        <div class="form-group">
                             <label class="col-sm-3 control-label">{{Heure de relève}}</label>
                             <div class="col-sm-3">
                                 <select class="form-control configuration eqLogicAttr" data-l1key="configuration" data-l2key="heure">


### PR DESCRIPTION
Proposition de modification pour le cas où, comme moi, on a plusieurs compteurs sur un même compte client.
- Ajout d'un champ de configuration "Identifiant compteur" (valeur de type 0, 1, 2 etc. attendue). Non obligatoire (0 utilisé par défaut)
- Envoi du paramètre "idAtr" avec l'identifiant compteur pour requêter les données du compteur concerné.
Testé avec succès sur eaudugrandlyon