### PR TITLE
Intégration de nouveaux sites basés sur celui de SUEZ (toutsurmoneau) et optimisation du code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![license](https://img.shields.io/github/license/NextDom/plugin-veolia_eau.svg)](./LICENSE) [![GitHub contributors](https://img.shields.io/github/contributors/NextDom/plugin-veolia_eau.svg)](../../graphs/contributors) [![GitHub release](https://img.shields.io/github/release/NextDom/plugin-veolia_eau.svg)](../../releases) [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.me/damien916) [![Waffle.io - Columns and their card count](https://badge.waffle.io/NextDom/plugin-veolia_eau.svg?columns=all)](https://waffle.io/NextDom/plugin-veolia_eau)
+[![license](https://img.shields.io/github/license/NextDom/plugin-veolia_eau.svg)](./LICENSE) [![GitHub contributors](https://img.shields.io/github/contributors/NextDom/plugin-veolia_eau.svg)](../../graphs/contributors) [![GitHub release](https://img.shields.io/github/release/NextDom/plugin-veolia_eau.svg)](../../releases) [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.me/damien916)
 
 ### Master: [![Build Status](https://travis-ci.org/NextDom/plugin-veolia_eau.svg?branch=master)](https://travis-ci.org/NextDom/plugin-veolia_eau)  [![Coverage Status](https://coveralls.io/repos/github/NextDom/plugin-veolia_eau/badge.svg?branch=master)](https://coveralls.io/github/NextDom/plugin-veolia_eau?branch=master)
 
@@ -6,7 +6,7 @@
 
 # Présentation:
 
-Ce plugin permet de récupérer le télé-relevé disponible sur les sites Internet de Veolia Eau / Veolia Méditerranée / Tout sur mon eau / Eau en ligne / Eau du grand Lyon
+Ce plugin permet de récupérer le télé-relevé disponible sur les sites Internet de : Veolia Eau / Veolia Méditerranée / Tout sur mon eau / Eau en ligne / Eau du grand Lyon / Société des Eaux de l'Essonne (SEE) / VEND'Ô - Tout sur mon eau / Eau de Sénart / Stéphanoise des Eaux / Seynoise des Eaux / Orléanaise des Eaux / Société des Eaux de l'Ouest Parisien (SEOP)
 
 
 [![Read the Docs](docs/images/veolia_eau_screen_shoot.png)](docs/images/veolia_eau_screen_shoot.png)

--- a/core/class/veolia_eau_process.class.php
+++ b/core/class/veolia_eau_process.class.php
@@ -316,7 +316,8 @@ class veolia_eau extends eqLogic {
             $url_site = 'www.toutsurmoneau.fr';
         } elseif ($website == 6) {
 			// SEE
-            $url_site = 'www.eauxdelessonne.com';
+            // $url_site = 'www.eauxdelessonne.com'; // Fermeture du site depuis le 1er juillet 2019.
+            $url_site = 'www.toutsurmoneau.fr';
         } elseif ($website == 7) {
             $url_site = 'vendo.toutsurmoneau.fr';
         } elseif ($website == 8) {

--- a/core/class/veolia_eau_process.class.php
+++ b/core/class/veolia_eau_process.class.php
@@ -943,6 +943,8 @@ class veolia_eau extends eqLogic {
         $info = str_replace("y:", "", $info);
         $info = str_replace("label:", "", $info);
         $info = str_replace("color:\"#c0bebf\",", "", $info);
+        $info = str_replace("color:\"#94dde7\"", "", $info);
+        $info = str_replace("color:\"#2abccf\"", "", $info);
         $info = str_replace("\"", "", $info);
         $info = explode( "|", $info);
         //log::add('veolia_eau', 'debug', print_r($info, true));

--- a/core/class/veolia_eau_process.class.php
+++ b/core/class/veolia_eau_process.class.php
@@ -312,6 +312,23 @@ class veolia_eau extends eqLogic {
             $url_site = 'www.eau-services.com';
         } elseif ($website == 3) {
             $url_site = 'agence.eaudugrandlyon.com';
+        } elseif ($website == 4) {
+            $url_site = 'www.toutsurmoneau.fr';
+        } elseif ($website == 6) {
+			// SEE
+            $url_site = 'www.eauxdelessonne.com';
+        } elseif ($website == 7) {
+            $url_site = 'vendo.toutsurmoneau.fr';
+        } elseif ($website == 8) {
+            $url_site = 'www.eauxdesenart.com';
+        } elseif ($website == 9) {
+            $url_site = 'www.stephanoise-eaux.fr';
+        } elseif ($website == 10) {
+            $url_site = 'www.seynoisedeseaux.fr';
+        } elseif ($website == 11) {
+            $url_site = 'www.orleanaise-des-eaux.fr';
+        }  elseif ($website == 12) {
+            $url_site = 'www.seop.fr';
         } else {
             $url_site = 'not defined';
         }
@@ -382,11 +399,19 @@ class veolia_eau extends eqLogic {
                 $extension='.csv';
                 break;
 
-           case 4:
-				$url_token = 'https://www.toutsurmoneau.fr/mon-compte-en-ligne/je-me-connecte';
+			// Sites basés sur "Tout sur mon eau" du groupe SUEZ.
+			case 4:
+			case 6:
+			case 7:
+			case 8:
+			case 9:
+			case 10:
+			case 11:
+			case 12:
+				$url_token = 'https://'.$url_site.'/mon-compte-en-ligne/je-me-connecte';
                 $tokenFieldName = '_csrf_token';
-                $url_login = 'https://www.toutsurmoneau.fr/mon-compte-en-ligne/je-me-connecte';
-                $url_consommation = 'https://www.toutsurmoneau.fr/mon-compte-en-ligne/historique-de-consommation';
+                $url_login = 'https://'.$url_site.'/mon-compte-en-ligne/je-me-connecte';
+                $url_consommation = 'https://'.$url_site.'/mon-compte-en-ligne/historique-de-consommation';
                 $getConsoInHtmlFile = false;
                 $datas = array(
                     'tsme_user_login[_username]='.urlencode($this->getConfiguration('login')),
@@ -395,30 +420,16 @@ class veolia_eau extends eqLogic {
                 $extension='.xls';
                 break;
 
-           case 5:
-                $url_login = 'https://espaceclients.eaudemarseille-metropole.fr/webapi/Utilisateur/authentification';
-                $url_consommation = 'https://www.toutsurmoneau.fr/mon-compte-en-ligne/historique-de-consommation';
-                $getConsoInHtmlFile = false;
-                $datas = array(
-                    'identifiant='.urlencode($this->getConfiguration('login')),
-                    'motDePasseMD5='.urlencode(md5($this->getConfiguration('password')))
-                );
-                $extension='.xls';
-                break;
-
-           case 6:
-            	log::add('SEE', 'debug', 'downloadToken : '.$downloadToken);
-            	$url_token = 'https://www.eauxdelessonne.com/mon-compte-en-ligne/je-me-connecte';
-                $tokenFieldName = '_csrf_token';
-                $url_login = 'https://www.eauxdelessonne.com/mon-compte-en-ligne/je-me-connecte';
-                $url_consommation = 'https://www.eauxdelessonne.com/mon-compte-en-ligne/historique-de-consommation';
-                $getConsoInHtmlFile = false;
-                $datas = array(
-                    'tsme_user_login[_username]='.urlencode($this->getConfiguration('login')),
-                    'tsme_user_login[_password]='.urlencode($this->getConfiguration('password'))
-                );
-                $extension='.xls';
-                break;
+			case 5:
+				$url_login = 'https://espaceclients.eaudemarseille-metropole.fr/webapi/Utilisateur/authentification';
+				$url_consommation = 'https://www.toutsurmoneau.fr/mon-compte-en-ligne/historique-de-consommation';
+				$getConsoInHtmlFile = false;
+				$datas = array(
+					'identifiant='.urlencode($this->getConfiguration('login')),
+					'motDePasseMD5='.urlencode(md5($this->getConfiguration('password')))
+				);
+				$extension='.xls';
+				break;
 
             case 1:
             default:
@@ -541,8 +552,8 @@ class veolia_eau extends eqLogic {
 			log::add('veolia_eau', 'debug', 'cURL response : '.urlencode($response));
 			log::add('veolia_eau', 'debug', 'cURL errno : '.curl_errno($ch));
 
-			// extraction du token de téléchargement pour ToutSurMonEau
-			if ($website == 4) {
+			// extraction du token de téléchargement pour ToutSurMonEau et autres sites basés sur celui de SUEZ (Vend'Ô, Eau de Sénart, etc.)
+			if ($website == 4 || $website == 6 || $website == 7 || $website == 8 || $website == 9 || $website == 10 || $website == 11 || $website == 12) {
                 require_once dirname(__FILE__).'/../../3rparty/SimpleHtmlParser/simple_html_dom.php';
                 $html = str_get_html($response);
                 $monthlyReportUrl = $html->find('div[id=export] a', 0)->href;
@@ -550,19 +561,8 @@ class veolia_eau extends eqLogic {
                 log::add('veolia_eau', 'debug', 'downloadToken : '.$downloadToken);
                 $month = date('m');
                 $year = date('Y');
-                $url_releve_csv = 'https://www.toutsurmoneau.fr/mon-compte-en-ligne/exporter-consommation/day/'.$downloadToken.'/'.$year.'/'.$month;
+                $url_releve_csv = 'https://'.$url_site.'/mon-compte-en-ligne/exporter-consommation/day/'.$downloadToken.'/'.$year.'/'.$month;
                 log::add('veolia_eau', 'debug', 'url csv : '.$url_releve_csv);
-			}
-          	if ($website == 6) {
-                require_once dirname(__FILE__).'/../../3rparty/SimpleHtmlParser/simple_html_dom.php';
-                $html = str_get_html($response);
-                $monthlyReportUrl = $html->find('div[id=export] a', 0)->href;
-                $downloadToken = substr($monthlyReportUrl, strrpos($monthlyReportUrl, '/') + 1);
-                log::add('SEE', 'debug', 'downloadToken : '.$downloadToken);
-                $month = date('m');
-                $year = date('Y');
-				$url_releve_csv = 'https://www.eauxdelessonne.com/mon-compte-en-ligne/exporter-consommation/day/'.$downloadToken.'/'.$year.'/'.$month;
-                log::add('SEE', 'debug', 'url csv : '.$url_releve_csv);
 			}
 		}
 
@@ -724,6 +724,13 @@ class veolia_eau extends eqLogic {
               break;
 
             case 4:
+			case 6:
+			case 7:
+			case 8:
+			case 9:
+			case 10:
+			case 11:
+			case 12:
                 $datasFetched=static::processCSV($file,$website);
                 break;
 
@@ -855,7 +862,7 @@ class veolia_eau extends eqLogic {
                       $conso = $line['B'];
                       $typeReleve = 0;
                   }
-                  elseif($website==4 || $website == 6) {
+                  elseif($website == 4 || $website == 6 || $website == 7 || $website == 8 || $website == 9 || $website == 10 || $website == 11 || $website == 12) {
                       $dateTemp = explode('-', $line['A']);
                       $date = $dateTemp[2].'-'.str_pad($dateTemp[1], 2, '0', STR_PAD_LEFT).'-'.str_pad($dateTemp[0], 2, '0', STR_PAD_LEFT);
                       $index = $line['C'];

--- a/desktop/php/veolia_eau.php
+++ b/desktop/php/veolia_eau.php
@@ -125,6 +125,12 @@ $eqLogics = eqLogic::byType($plugin->getId());
                                     <option value="3">Service Eau du Grand Lyon</option>
                                     <option value="4">Tout sur mon eau / Eau en ligne</option>
                                     <option value="6">Société des eaux de l'Essonne</option>
+									<option value="7">VEND'Ô - Tout sur mon eau</option>
+									<option value="8">Eau de Sénart</option>
+									<option value="9">Stéphanoise des Eaux</option>
+									<option value="10">Seynoise des Eaux</option>
+									<option value="11">Orléanaise des Eaux</option>
+									<option value="12">Société des Eaux de l'Ouest Parisien (SEOP)</option>
                                 </select>
                             </div>
                         </div>

--- a/docs/fr_FR/configuration.md
+++ b/docs/fr_FR/configuration.md
@@ -3,7 +3,7 @@
 Vous devez renseigner les identifiants utilisés pour vous connecter votre site
 - Veolia Eau: https://www.service-client.veoliaeau.fr
 - Veolia Méditerranée: https://www.eau-services.com
-- Tout sur mon eau / Eau en ligne: https://www.eau-en-ligne.com
+- Tout sur mon eau / Eau en ligne: https://www.toutsurmoneau.fr/
 
 Le "Service Télé relevé" doit être activé chez Veolia (Vous pouvez le faire depuis le site Internet dans la rubrique "Vos contrats" si votre compteur d'eau le permet).
 

--- a/docs/fr_FR/configuration.md
+++ b/docs/fr_FR/configuration.md
@@ -1,9 +1,16 @@
 # Configuration
 
 Vous devez renseigner les identifiants utilisés pour vous connecter votre site
-- Veolia Eau: https://www.service-client.veoliaeau.fr
-- Veolia Méditerranée: https://www.eau-services.com
-- Tout sur mon eau / Eau en ligne: https://www.toutsurmoneau.fr/
+- Veolia Eau : https://www.service-client.veoliaeau.fr
+- Veolia Méditerranée : https://www.eau-services.com
+- Service Eau du Grand Lyon : https://agence.eaudugrandlyon.com/
+- Tout sur mon eau / Eau en ligne / Société des Eaux de l'Essonne (SEE) : https://www.toutsurmoneau.fr/
+- VEND'Ô - Tout sur mon eau : https://vendo.toutsurmoneau.fr/
+- Eau de Sénart : https://www.eauxdesenart.com/
+- Stéphanoise des Eaux : https://www.stephanoise-eaux.fr/
+- Seynoise des Eaux : https://www.seynoisedeseaux.fr/
+- Orléanaise des Eaux : https://www.orleanaise-des-eaux.fr/
+- Société des Eaux de l'Ouest Parisien (SEOP) : https://www.seop.fr/
 
 Le "Service Télé relevé" doit être activé chez Veolia (Vous pouvez le faire depuis le site Internet dans la rubrique "Vos contrats" si votre compteur d'eau le permet).
 

--- a/docs/fr_FR/presentation.md
+++ b/docs/fr_FR/presentation.md
@@ -12,4 +12,4 @@ Retrouvez le sur le Market Jeedom [ici](https://www.jeedom.com/market/index.php?
 
 # Forum
 
-Lien vers le forum [ici](https://www.jeedom.com/forum/viewtopic.php?f=140&t=21200&start=500)
+Lien vers le forum [ici](https://community.jeedom.com/tag/plugin-veolia_eau)


### PR DESCRIPTION
Bonjour,

J'ai modifié des fichiers pour l'intégration de la SemOp (Société d’économie mixte à Opération unique) VEND'Ô. Celle-ci est dépendante de Suez (https://www.toutsurmoneau.fr), mais redirige la page vers celle de la SemOp VEND'Ô (https://vendo.toutsurmoneau.fr), ce qui pose problème pour la récupération des données.

Le code a été optimisé en conséquence suite à l'ajout de la SemOP et en ai profité pour ajouter des sites basés sur celui de SUEZ (comme suite à la demande : https://community.jeedom.com/t/erreur-sur-la-fonction-cronhourly-du-plugin-access-to-undeclared-static-property-phpexcel-worksheet-invalidcharacters/51673/3).

Mise à jour de la documentation suite à l'ajout de nouveaux sites, du lien vers le forum, et redirection de "Eaux de l'Essonne" vers "Tout Sur Mon Eau".

Bien cordialement,

Xandr3