### PR TITLE
Fix for eau-services.com

### DIFF
--- a/core/class/veolia_eau_process.class.php
+++ b/core/class/veolia_eau_process.class.php
@@ -943,6 +943,8 @@ class veolia_eau extends eqLogic {
         $info = str_replace("y:", "", $info);
         $info = str_replace("label:", "", $info);
         $info = str_replace("color:\"#c0bebf\",", "", $info);
+        $info = str_replace("color:\"#94dde7\",", "", $info);
+        $info = str_replace("color:\"#2abccf\",", "", $info);
         $info = str_replace("\"", "", $info);
         $info = explode( "|", $info);
         //log::add('veolia_eau', 'debug', print_r($info, true));

--- a/core/class/veolia_eau_process.class.php
+++ b/core/class/veolia_eau_process.class.php
@@ -943,8 +943,8 @@ class veolia_eau extends eqLogic {
         $info = str_replace("y:", "", $info);
         $info = str_replace("label:", "", $info);
         $info = str_replace("color:\"#c0bebf\",", "", $info);
-        $info = str_replace("color:\"#94dde7\",", "", $info);
-        $info = str_replace("color:\"#2abccf\",", "", $info);
+        $info = str_replace("color:\"#94dde7\"", "", $info);
+        $info = str_replace("color:\"#2abccf\"", "", $info);
         $info = str_replace("\"", "", $info);
         $info = explode( "|", $info);
         //log::add('veolia_eau', 'debug', print_r($info, true));


### PR DESCRIPTION
Depuis quelques mois, le plugin ne fonctionne plus pour Veolia Méditerranée (https://www.eau-services.com/).
En effet, le parsing HTML échoue car de nouvelles données doivent être exclues (nouveaux codes couleur).
Avec la modification proposée, cela refonctionne.