### PR TITLE
Fix parsing for eau-services.com

### DIFF
--- a/core/class/veolia_eau_process.class.php
+++ b/core/class/veolia_eau_process.class.php
@@ -965,9 +965,7 @@ class veolia_eau extends eqLogic {
         $info = str_replace("{", "", $info);
         $info = str_replace("y:", "", $info);
         $info = str_replace("label:", "", $info);
-        $info = str_replace("color:\"#c0bebf\",", "", $info);
-        $info = str_replace("color:\"#94dde7\"", "", $info);
-        $info = str_replace("color:\"#2abccf\"", "", $info);
+        $info = preg_replace('/color:"#[a-f0-9]{6}",?/i', "", $info);
         $info = str_replace("\"", "", $info);
         $info = explode( "|", $info);
         //log::add('veolia_eau', 'debug', print_r($info, true));


### PR DESCRIPTION
Parsing is failing because the color is now 2abbcf.
Replace hard-coded colors by a regex to support any color with or without trailing comma.